### PR TITLE
Shaman

### DIFF
--- a/data/Shaman.lua
+++ b/data/Shaman.lua
@@ -172,16 +172,16 @@ lib:__RegisterSpells("SHAMAN", "60000", 5, {
 	[159101] = { -- Echo of the Elements (Elemental buff)
 		 8056, -- Frost Shock
 		51505, -- Lava Burst
-		61882, -- Earthquake (Talent, Elemental)
+		61882, -- Earthquake
 	},
 	[159103] = { -- Echo of the Elements (Enhancement buff)
-		 1535, -- Fire Nova (Talent, Enhancement)
+		 1535, -- Fire Nova
 		17364, -- Stormstrike
 		60103, -- Lava Lash
 	},
 	[159105] = { -- Echo of the Elements (Restoration buff)
 		61295, -- Riptide
 		73685, -- Unleash Life
-		51886, -- Purify Spirit (Talent, Restoration)
+		77130, -- Purify Spirit
 	},
 })

--- a/data/Shaman.lua
+++ b/data/Shaman.lua
@@ -33,7 +33,7 @@ along with LibPlayerSpells-1.0.  If not, see <http://www.gnu.org/licenses/>.
 
 local lib = LibStub("LibPlayerSpells-1.0")
 if not lib then return end
-lib:__RegisterSpells("SHAMAN", "60000", 5, {
+lib:__RegisterSpells("SHAMAN", "60000", 6, {
 	COOLDOWN = {
 		[ 2062] = "SURVIVAL", -- Earth Elemental Totem
 		  5394, -- Healing Stream Totem


### PR DESCRIPTION
On a side note: Maybe it is better not to show the duration of Echo of the Elements on the modified spells as this may hide their individual effects' duration. I think it would be better if we create ABA rules to hint the modified spells when Echo of the Elements is on the player. What do you think?